### PR TITLE
defaults xlsform_convert(pretty_print = False)

### DIFF
--- a/qtools3/xlsform.py
+++ b/qtools3/xlsform.py
@@ -80,7 +80,7 @@ class Xlsform:
         return wb
 
     def xlsform_convert(self, validate=True):
-        msg = xls2xform_convert(self.path, self.outpath, validate=validate)
+        msg = xls2xform_convert(self.path, self.outpath, validate=validate, pretty_print = False )
         self.assert_itemsets_moved()
         return msg
 


### PR DESCRIPTION
added pretty_print argument to xls2xform_convert() to deactive the _to_pretty_xml()

This is needed to remove the extra white space from the XML file, and reducing its size. 